### PR TITLE
Tried to build on Windows and start working with it

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^docs$
+^data-raw$
+^\.Rbuildignore$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,21 @@
 Package: tidymetadata
 Type: Package
 Date: 2017-04-22
-Title: Functions to Generate Tidy Metadata from SPSS, Stata and SAS binary data files
-Version: 0.2.0
+Title: Functions to Generate Tidy Metadata from SPSS, Stata and SAS
+    Binary Data Files
+Version: 0.2.1
 Author: Markus Kainu
-Authors@R: person("Markus", "Kainu", email = "markuskainu@gmail.com", role = c("aut", "cre"))
+Authors@R: person("Markus", "Kainu", 
+email = "markuskainu@gmail.com", 
+role = c("aut", "cre"))
 Maintainer: Markus Kainu <markuskainu@gmail.com>
-Description: This package provides a technical backbone for tidy metadata approach
-    for working with social surveys in R
-Imports: dplyr, labelled
+Description: This package provides a technical backbone for tidy metadata
+    approach for working with social surveys in R
+Imports: 
+    dplyr,
+    labelled,
+    magrittr,
+    tibble
 License: MIT
 Encoding: UTF-8
 LazyData: true

--- a/R/create_metadata.R
+++ b/R/create_metadata.R
@@ -1,20 +1,21 @@
-#' @title Create a metadata from labeled data.frame SPSS, Stata or SAS export
-#' @description Create a metadata from labeled data.frame imported from SPSS, Stata or SAS file
-#' @param data a labeled data.frame imported from Stata, SPSS or SAS using haven
+#' @title Export The Metadata from Labelled Data Frame
+#'
+#' @description Create a metadata from labelled data.frame
+#' imported from SPSS, Stata or SAS file
+#' @param data a labelled data.frame imported from Stata,
+#' SPSS or SAS using haven
 #' @author Markus Kainu <markuskainu@gmail.com>
-#' @return data.frame
+#' @return Returns a metadata data frame with five columns.
+#' Each row corresponds to a column in the \code{'data'} data frame.
 #' @examples
 #'  \dontrun{
 #'  create_metadata(data = imported_spss_data)
 #'  }
 #'
 #' @rdname create_metadata
-#' @import dplyr labelled
 #' @export
 
 create_metadata <- function(data){
-  library(dplyr)
-  library(labelled)
   d <- data
   meta_df <- data_frame()
   for (i in 1:ncol(d)){

--- a/R/create_metadata2.R
+++ b/R/create_metadata2.R
@@ -1,0 +1,96 @@
+#' @title Export The Metadata from Labelled Data Frame
+#' @description Create a metadata from labelled data.frame
+#' imported from SPSS, Stata or SAS file
+#' @param data a labelled data.frame imported from Stata, SPSS
+#'  or SAS using haven
+#' @author Daniel Antal <daniel.antal@ceemid.eu>
+#' @return Returns a metadata data frame with five columns.
+#' Each row corresponds to a column in the \code{'data'} data frame.
+#' @examples
+#'  \dontrun{
+#'  create_metadata2(data = imported_spss_data)
+#'  }
+#'
+#' @rdname create_metadata2
+#' @importFrom dplyr distinct bind_cols
+#' @importFrom tibble tibble
+#' @importFrom tidyr pivot_longer
+#' @importFrom purrr set_names map
+#' @importFrom haven is.labelled
+#' @export
+
+create_metadata2 <- function(data){
+
+  d <- data
+  fn_label  <- function(a) {
+    if( is.null(attributes(a)$label) ) { return(NA_character_ )
+    } else {as.character(attributes(a)$label) }
+  }
+
+  fn_labels_old  <- function(a) {
+
+    if ("labels" %in% names ( attributes(a)) ) {
+      list ( labels = attributes(a)$labels,
+               label = names(attributes(a)$labels),
+               value = attributes(a)$label)
+    } else {
+      list ( labels = attributes(a)$labels,
+               label = NA_character_,
+               value = NA_character_ )
+
+    }
+  }
+
+  fn_labels <- function(a) {
+   if ( 'labels' %in% names (a) ) {
+     list(names = names(a$labels),
+          values = unname(a$labels))
+   }  else {
+     list(names = NA_character_,
+          values = NA_character_)
+   }
+  }
+
+  fn_labels(a)
+
+  meta_df <- tibble(
+    code  = names(d),
+    name  =  vapply ( d, fn_label,  character(1) ),
+    class = ifelse ( test = vapply( d, is.character, logical(1) ),
+                     yes = "character",
+                     no  = ifelse( test = vapply(d, is.labelled, logical(1)),
+                                   yes =  "labelled",
+                                   no = "numeric")))
+
+
+
+  attribs <- map ( data, attributes)
+  my_attribs <- map( attribs, fn_labels)
+  value_list <- sapply(my_attribs, "[", -(1))
+
+  tested <- do.call(rbind.data.frame, value_list)
+  tested$code <- meta_df$code
+  new_names <- c(paste0("var", 1:(ncol(tested)-1)),
+                 "code")
+  tested <- purrr::set_names ( tested, nm = new_names )
+
+  wide_cols <- c(paste0("var", 1:(ncol(tested)-1)))
+  long_form <-  tidyr::pivot_longer (
+                       data = tested,
+                       cols = wide_cols,
+                       values_to = 'value',
+                       names_to = 'var') %>%
+    distinct ( code, value , .keep_all = T)
+
+  name_list <- unlist(sapply(my_attribs, "[[", 1))
+  attrib_df <- setNames(stack(setNames(name_list, value_list))[2:1],
+           c('value2', 'label'))
+
+  metadata <- bind_cols ( long_form, attrib_df ) %>%
+    select ( -all_of(c("value2", "var")))
+
+  return_metadata <- meta_df %>%         ## assing for code checking only
+    left_join ( metadata, by = 'code' )
+
+  return_metadata
+}

--- a/data-raw/DATASET.R
+++ b/data-raw/DATASET.R
@@ -1,0 +1,3 @@
+## code to prepare `DATASET` dataset goes here
+
+usethis::use_data(DATASET, overwrite = TRUE)

--- a/data-raw/DATASET.R
+++ b/data-raw/DATASET.R
@@ -1,3 +1,0 @@
-## code to prepare `DATASET` dataset goes here
-
-usethis::use_data(DATASET, overwrite = TRUE)

--- a/vignettes/tidymetadata_tutorial.Rmd
+++ b/vignettes/tidymetadata_tutorial.Rmd
@@ -75,12 +75,16 @@ library(haven)
 ## ".." part if you are working to the project root.
 
 if(file.exists(file.path("..", "data-raw", "datasets", "data.sav"))) {
-  spss  <- read_sav( file.path("..", "data-raw", "datasets", "data.sav") )
+  spss  <- read_sav( file.path("..", "data-raw", 
+                               "datasets", "data.sav") )
+} else {
+  stop("The file downloads were not successful.")
 }
 
-stata <- read_dta( file.path("..", "data-raw", "datasets", "data.dta"))
-sas   <- read_sas( file.path("..", "data-raw", "datasets", "data.sas7bdat"))
-#the stata and sas files do not open on windows.
+stata <- read_dta( file.path("..", "data-raw",
+                             "datasets", "data.dta"))
+sas   <- read_sas( file.path("..", "data-raw", "datasets",
+                             "data.sas7bdat"))
 ```
 
 They all have the same number of cases and variables, and seem to share similar structure with variable labels and value labels as attributes. However, when applying `str()` function for all three datas we can spot that imported spss and stata files seem to have identical structure and somewhat richer than sas file has.
@@ -172,7 +176,7 @@ Lets print the metadata out of those variables
 
 ```{r}
 # re-creating metadata
-spss  <- read_sav("./datasets/data.sav")
+spss  <- read_sav(file.path("..", "data-raw", "datasets", "data.sav"))
 spss_meta <- create_metadata(spss)
 meta_spss[meta_spss$code %in% c("sex","pmi","educ"),] %>% 
   kable()
@@ -315,19 +319,19 @@ You can then re-create spss-data from stripped data & meta-data using the functi
 
 **Add the variable labels ie. variable names or questions**
 
-```{r}
+```{r eval=FALSE}
 d <- create_labelled_data(data = spss, metadata = meta_spss)
 ```
 
 And this is how the first 15 variables look like with the attributes
 
-```{r}
+```{r eval=FALSE}
 str(d[1:15])
 ```
 
 And you can then save it as .sav using haven
 
 ```{r, eval=FALSE}
-  haven::write_sav(d, path = "./lis_spss.sav")
+  haven::write_sav(d, path = file.path("..", "data-raw", "lis_spss.sav")))
 ```
 

--- a/vignettes/tidymetadata_tutorial.Rmd
+++ b/vignettes/tidymetadata_tutorial.Rmd
@@ -41,15 +41,15 @@ Survey datas are in most cases still disseminated in either SAS, SPSS or Stata f
 
 ```{r downloads}
 library(tidyverse)
-if (! dir.exists('data-raw') ) {
-  dir.create( "data-raw" )
+if (! dir.exists(file.path('..', 'data-raw')) ) {
+  dir.create( file.path("..", "data-raw" ))
 } 
 
-if (! dir.exists(file.path('data-raw', 'datasets')) ) {
-  dir.create( file.path('data-raw', 'datasets') ) 
+if (! dir.exists(file.path('..', 'data-raw', 'datasets')) ) {
+  dir.create( file.path('..', 'data-raw', 'datasets') ) 
 }
 
-if ( ! file.exists(file.path("data-raw", "datasets", "data.sav")) ){
+if ( ! file.exists(file.path("..", "data-raw", "datasets", "data.sav")) ){
   # SPSS-file
   download.file(url = "http://www.lisdatacenter.org/wp-content/uploads/it04ip.sav",
                 destfile = file.path("..", "data-raw",
@@ -62,7 +62,6 @@ if ( ! file.exists(file.path("data-raw", "datasets", "data.sav")) ){
   download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.sas7bdat", file.path("..", "data-raw", "datasets", "data.sas7bdat"), 
               method = 'auto')
 }
-
 ```
 
 Package [`haven`](http://haven.tidyverse.org/) provides handy functions for reading in such formats.
@@ -73,9 +72,9 @@ library(haven)
 ## In this example the working directory is "./vignettes", remove the 
 ## ".." part if you are working to the project root.
 
-spss  <- read_sav( file.path("..", "data-raw", "data.sav"))
-#stata <- read_dta( file.path("..", "data-raw", "datasets", "data.dta"))
-#sas   <- read_sas( file.path("..", "data-raw", "datasets", "data.sas7bdat"))
+spss  <- read_sav( file.path("..", "data-raw", "datasets", "data.sav") )
+stata <- read_dta( file.path("..", "data-raw", "datasets", "data.dta"))
+sas   <- read_sas( file.path("..", "data-raw", "datasets", "data.sas7bdat"))
 #the stata and sas files do not open on windows.
 ```
 

--- a/vignettes/tidymetadata_tutorial.Rmd
+++ b/vignettes/tidymetadata_tutorial.Rmd
@@ -332,6 +332,7 @@ str(d[1:15])
 And you can then save it as .sav using haven
 
 ```{r, eval=FALSE}
-  haven::write_sav(d, path = file.path("..", "data-raw", "lis_spss.sav")))
+  haven::write_sav(d, path = file.path("..", "data-raw", 
+                                       "lis_spss.sav")))
 ```
 

--- a/vignettes/tidymetadata_tutorial.Rmd
+++ b/vignettes/tidymetadata_tutorial.Rmd
@@ -54,14 +54,16 @@ if ( ! file.exists(file.path("..", "data-raw", "datasets", "data.sav")) ){
   download.file(url = "http://www.lisdatacenter.org/wp-content/uploads/it04ip.sav",
                 destfile = file.path("..", "data-raw",
                                      "datasets", "data.sav"),
-                method = 'auto')
+                method = 'curl')
   # Stata-file
   download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.dta", file.path("..", "data-raw", "datasets", "data.dta"), 
-              method = 'auto')
+              method = 'curl')
   # SAS-file
   download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.sas7bdat", file.path("..", "data-raw", "datasets", "data.sas7bdat"), 
-              method = 'auto')
+              method = 'curl')
 }
+# method = 'curl' works on Windows machines. You can set this to 'auto' 
+# or other on different systems if you get invalid files.
 ```
 
 Package [`haven`](http://haven.tidyverse.org/) provides handy functions for reading in such formats.
@@ -72,7 +74,10 @@ library(haven)
 ## In this example the working directory is "./vignettes", remove the 
 ## ".." part if you are working to the project root.
 
-spss  <- read_sav( file.path("..", "data-raw", "datasets", "data.sav") )
+if(file.exists(file.path("..", "data-raw", "datasets", "data.sav"))) {
+  spss  <- read_sav( file.path("..", "data-raw", "datasets", "data.sav") )
+}
+
 stata <- read_dta( file.path("..", "data-raw", "datasets", "data.dta"))
 sas   <- read_sas( file.path("..", "data-raw", "datasets", "data.sas7bdat"))
 #the stata and sas files do not open on windows.

--- a/vignettes/tidymetadata_tutorial.Rmd
+++ b/vignettes/tidymetadata_tutorial.Rmd
@@ -39,30 +39,44 @@ Tidymetadata is not replacement for dedicated packages to work with survey data 
 Survey datas are in most cases still disseminated in either SAS, SPSS or Stata formats with metadata included in variable and value labels. We first download the **demo** files freely available at from [Luxembourg Income Study](http://www.lisdatacenter.org/).
 
 
-```{r}
+```{r downloads}
 library(tidyverse)
-if (!file.exists("./datasets/data.sav")){
+if (! dir.exists('data-raw') ) {
+  dir.create( "data-raw" )
+} 
 
-  dir.create("./datasets")
+if (! dir.exists(file.path('data-raw', 'datasets')) ) {
+  dir.create( file.path('data-raw', 'datasets') ) 
+}
+
+if ( ! file.exists(file.path("data-raw", "datasets", "data.sav")) ){
   # SPSS-file
-  download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.sav", "./datasets/data.sav")
+  download.file(url = "http://www.lisdatacenter.org/wp-content/uploads/it04ip.sav",
+                destfile = file.path("..", "data-raw",
+                                     "datasets", "data.sav"),
+                method = 'auto')
   # Stata-file
-  download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.dta", "./datasets/data.dta")
+  download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.dta", file.path("..", "data-raw", "datasets", "data.dta"), 
+              method = 'auto')
   # SAS-file
-  download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.sas7bdat", "./datasets/data.sas7bdat")
-
+  download.file("http://www.lisdatacenter.org/wp-content/uploads/it04ip.sas7bdat", file.path("..", "data-raw", "datasets", "data.sas7bdat"), 
+              method = 'auto')
 }
 
 ```
 
-Package [`haven`](http://haven.tidyverse.org/) provides handy functions for reading in such formats
+Package [`haven`](http://haven.tidyverse.org/) provides handy functions for reading in such formats.
 
 
 ```{r}
 library(haven)
-spss  <- read_sav("./datasets/data.sav")
-stata <- read_dta("./datasets/data.dta")
-sas   <- read_sas("./datasets/data.sas7bdat")
+## In this example the working directory is "./vignettes", remove the 
+## ".." part if you are working to the project root.
+
+spss  <- read_sav( file.path("..", "data-raw", "data.sav"))
+#stata <- read_dta( file.path("..", "data-raw", "datasets", "data.dta"))
+#sas   <- read_sas( file.path("..", "data-raw", "datasets", "data.sas7bdat"))
+#the stata and sas files do not open on windows.
 ```
 
 They all have the same number of cases and variables, and seem to share similar structure with variable labels and value labels as attributes. However, when applying `str()` function for all three datas we can spot that imported spss and stata files seem to have identical structure and somewhat richer than sas file has.
@@ -81,11 +95,11 @@ Once we have datafiles in R, we use function `tidymetadata::create_meta()` to cr
 
 Lets apply the `tidymetadata::create_meta()`-function for each data:
 
-```{r}
+```{r createmetadata}
 library(tidymetadata)
-meta_spss <- create_metadata(spss)
+meta_spss  <- create_metadata(spss)
 meta_stata <- create_metadata(stata)
-meta_sas <- create_metadata(sas)
+meta_sas   <- create_metadata(sas)
 ```
 
 And, lets subset each data into variable `sex` and pile up the resulting rows:


### PR DESCRIPTION
I made several small changes to make the vignette platform independent and confirm more to current documentation standards.  This is related to the use of file.path(), which creates platform independent path names (and requried by CRAN) and a more explicit configuration of the download.file() function, I used method = 'curl', because the 'auto' method resulted in character coding issues of the STATA and SAS files. 

However, the last two chunks do not run at all, and that may be related to either some problem in the code or recent changes in the labelled dependency. 